### PR TITLE
Fix typo in trailing slash comment

### DIFF
--- a/content/posts/2020-05-22-gatsby-redirect-from/index.md
+++ b/content/posts/2020-05-22-gatsby-redirect-from/index.md
@@ -53,7 +53,7 @@ redirect_from:
   - /goodie-updated-aperture-file-types-v11/
   - /aperture-file-types-v12-released/
   - /2008/04/aperture-file-types/
-  # note: traling slashes are required
+  # note: trailing slashes are required
 ---
 
 ```


### PR DESCRIPTION
Replaces 'traling' with 'trailing'